### PR TITLE
51 - Admin Users

### DIFF
--- a/lib/heads_up/accounts/user.ex
+++ b/lib/heads_up/accounts/user.ex
@@ -5,6 +5,7 @@ defmodule HeadsUp.Accounts.User do
   schema "users" do
     field :email, :string
     field :username, :string
+    field :is_admin, :boolean, default: false
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
     field :current_password, :string, virtual: true, redact: true

--- a/lib/heads_up_web/router.ex
+++ b/lib/heads_up_web/router.ex
@@ -40,11 +40,14 @@ defmodule HeadsUpWeb.Router do
   scope "/", HeadsUpWeb do
     pipe_through [
       :browser,
-      :require_authenticated_user
+      :require_authenticated_user,
+      :require_admin
     ]
+
     live_session :admin,
       on_mount: [
-        {HeadsUpWeb.UserAuth, :ensure_authenticated}
+        {HeadsUpWeb.UserAuth, :ensure_authenticated},
+        {HeadsUpWeb.UserAuth, :ensure_admin}
       ] do
       live "/admin/incidents", AdminIncidentLive.Index
       live "/admin/incidents/new", AdminIncidentLive.Form, :new
@@ -56,7 +59,7 @@ defmodule HeadsUpWeb.Router do
 
       live "/categories/:id", CategoryLive.Show, :show
       live "/categories/:id/show/edit", CategoryLive.Show, :edit
-  end
+    end
   end
 
   # Other scopes may use custom stacks.

--- a/lib/heads_up_web/user_auth.ex
+++ b/lib/heads_up_web/user_auth.ex
@@ -164,6 +164,20 @@ defmodule HeadsUpWeb.UserAuth do
     end
   end
 
+  def on_mount(:ensure_admin, _params, _session, socket) do
+    if socket.assigns.current_user.is_admin do
+      {:cont, socket}
+    else
+      socket =
+        socket
+        |> Phoenix.LiveView.put_flash(:error, "You must be an admin to access this page.")
+        |> Phoenix.LiveView.redirect(to: ~p"/")
+
+      {:halt, socket}
+    end
+  end
+
+
   def on_mount(:redirect_if_user_is_authenticated, _params, session, socket) do
     socket = mount_current_user(socket, session)
 
@@ -212,6 +226,23 @@ defmodule HeadsUpWeb.UserAuth do
       |> halt()
     end
   end
+
+  @doc """
+  For routes where the admin flag must be set on an account.
+  """
+  def require_admin(conn, _opts) do
+    if conn.assigns.current_user.is_admin do
+      conn
+    else
+      conn
+      |> put_flash(:error, "You must be an admin to access this page.")
+      |> redirect(to: ~p"/")
+      |> halt()
+    end
+  end
+
+
+
 
   defp put_token_in_session(conn, token) do
     conn

--- a/priv/repo/migrations/20250508105451_add_is_admin_to_users.exs
+++ b/priv/repo/migrations/20250508105451_add_is_admin_to_users.exs
@@ -1,0 +1,10 @@
+defmodule HeadsUp.Repo.Migrations.AddIsAdminToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :is_admin, :boolean, default: false
+    end
+
+  end
+end


### PR DESCRIPTION
There is now a plug for requiring admin users, an on_mount callback for live views and migrations to get the admin flag set.

closes #55 