### PR TITLE
54 - Streaming New Tickets

### DIFF
--- a/lib/heads_up/incidents.ex
+++ b/lib/heads_up/incidents.ex
@@ -8,6 +8,13 @@ defmodule HeadsUp.Incidents do
     Repo.all(Incident)
   end
 
+  def list_responses(incident) do
+    incident
+    |> Ecto.assoc(:responses)
+    |> preload(:user)
+    |> order_by(desc: :inserted_at)
+    |> Repo.all()
+  end
 
   def filter_incidents(filter) do
     Incident


### PR DESCRIPTION
Now rendering out everything like it should.

Responses to incidents are listed and counted. When a new response is created the live view updates with a correct count of responses and the freshly created response is inserted into the stream at the top.

Closes #58 